### PR TITLE
Remove Mac-only ⌘K badge from search button

### DIFF
--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -20,7 +20,6 @@
       stroke-linecap="round"></path>
   </svg>
   <span class="lbl">Search</span>
-  <kbd class="kbd">⌘K</kbd>
 </button>
 
 <dialog id="search-dialog" class="search-dialog" aria-label="Search docs and blog">
@@ -235,15 +234,6 @@
     color: var(--cyan);
   }
 
-  .search-open .kbd {
-    font-family: var(--font-mono);
-    font-size: 0.72rem;
-    padding: 1px 5px;
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-  }
-
   /* dialog */
   .search-dialog {
     margin: 12vh auto auto;
@@ -365,8 +355,7 @@
   }
 
   @media (max-width: 640px) {
-    .search-open .lbl,
-    .search-open .kbd {
+    .search-open .lbl {
       display: none;
     }
   }


### PR DESCRIPTION
Removes the `⌘K` keyboard hint badge from the search button in the header — not everyone is on a Mac, and the symbol is meaningless on Windows/Linux.

The shortcuts themselves are unchanged: Ctrl+K / Cmd+K and `/` still open search, and the `aria-keyshortcuts` attribute advertising both is kept. Also drops the now-unused badge CSS and its mobile-hide rule.